### PR TITLE
Use total revenue instead of records

### DIFF
--- a/get-report.py
+++ b/get-report.py
@@ -11,6 +11,6 @@ url = "{}{}".format(sf.instance_url, path)
 resp = requests.get(url, headers=sf.headers)
 content = json.loads(resp.text)
 print(content)
-the_good_stuff = content["factMap"]["T!T"]["aggregates"][0]
+the_good_stuff = content["factMap"]["T!T"]["aggregates"][0] # change this to 3 for SMD/FMD
 print(the_good_stuff)
 push_to_s3(filename="gtd2022.json", contents=the_good_stuff)

--- a/get-report.py
+++ b/get-report.py
@@ -11,6 +11,6 @@ url = "{}{}".format(sf.instance_url, path)
 resp = requests.get(url, headers=sf.headers)
 content = json.loads(resp.text)
 print(content)
-the_good_stuff = content["factMap"]["T!T"]["aggregates"][3]
+the_good_stuff = content["factMap"]["T!T"]["aggregates"][0]
 print(the_good_stuff)
 push_to_s3(filename="gtd2022.json", contents=the_good_stuff)


### PR DESCRIPTION
Usually membership drives display members, which targets a different line in the report. The Giving Tuesday campaign is based on a dollar amount instead so we'll change this to get the thermometer job to successfully run